### PR TITLE
Analysis and Visualization for HQ Done

### DIFF
--- a/cirq/HelloQuantum/hq_1_1.py
+++ b/cirq/HelloQuantum/hq_1_1.py
@@ -9,8 +9,6 @@ analyzing the circuit
 """
 
 import cirq as cq;
-import numpy as np;
-import hqAnalysis.hqhelp as hh;
 
 #%%
 
@@ -51,38 +49,4 @@ print(result)
 # get histogram counts of each result
 print(result.histogram(key="q0"))
 print(result.histogram(key="q1"))
-
-#%% 
-
-# simulate the run and gain access to state information
-
-s_res = sim.simulate(circuit,qubit_order=[qubits[0],qubits[1]])
-
-# see results 
-print(s_res)
-# See the final state --> [a b c d] for a00+b01+c10+d11
-print(np.around(s_res.final_state,3))
-
-## the probability of measuring a state with amplitude a is 
-##  abs(a)**2
-
-p = abs(s_res.final_state)**2
-print(p)
-
-
-#%%
-
-# Step through moments and print out the state after each moment.
-for i, step in enumerate(sim.simulate_moment_steps(circuit)):
-    print('state at step %d: %s' % (i+1, np.around(step.state(), 3)))
-    print('prob(%d) at step %d: %s' % (i+1,i+1, np.around(abs(step.state())**2,3)))
-    hh.p_bars_std(np.around(step.state(), 3))
-    hh.p_bars_bell(np.around(step.state(), 3))
-
-#%%
-    
-hh.p_bars_std_all(sim.simulate_moment_steps(circuit))
-hh.p_bars_bell_all(sim.simulate_moment_steps(circuit))
-
-
 

--- a/cirq/HelloQuantum/hq_3_3.py
+++ b/cirq/HelloQuantum/hq_3_3.py
@@ -50,7 +50,7 @@ print(circuit)
 #%%
 
 # "Run" the computation 20 times.
-result = sim.run(circuit, repetitions=10)
+result = sim.run(circuit, repetitions=25)
 
 # view results
 print(result)
@@ -76,6 +76,7 @@ hh.hq_grid(s1.state())
 
 s2 = next(puz)
 hh.hq_grid(s2.state())
+
 
 #%%
 


### PR DESCRIPTION
This resolves #11. For now. The current state of hqhelp is that
it allows you to plot measurement probabilities for every space
in the HelloQuantum puzzle using hq_grid. The module also
provides functions for computing states in any of the basis
implied by the available measurements as well as density
operators for the single qubit systems. All told, you can
look at a visual picture (hq_grid), probability distributions (p_*),
quantum states (to_*), and single bit density operators.