### PR TITLE
fixed a copy error in the h2_example ansatz

### DIFF
--- a/openfermion-cirq/h2_example.py
+++ b/openfermion-cirq/h2_example.py
@@ -13,13 +13,14 @@ documentation.
 import openfermion as of
 import cirq as cq
 import openfermioncirq as ofcq
-from openfermioncirq.optimization import COBYLA, OptimizationParams
+from openfermioncirq.optimization import ScipyOptimizationAlgorithm, OptimizationParams
 import matplotlib.pyplot as pyplot
 from openfermionpsi4 import run_psi4
 
 
 #%%
 
+# class derived from ofcq.VariationalAnzsatz
 class MyAnsatz(ofcq.VariationalAnsatz):
     
     def params(self):
@@ -30,7 +31,7 @@ class MyAnsatz(ofcq.VariationalAnsatz):
         """Produce the operations of the ansatz circuit."""
         q0, q1, q2, q3 = qubits
         yield cq.H(q0), cq.H(q1), cq.H(q2)
-        yield (cq.X**0.5).on(q3)
+        yield (cq.X**-0.5).on(q3)
         
         yield cq.CNOT(q0, q1), cq.CNOT(q1, q2), cq.CNOT(q2, q3)
         yield (cq.Z._with_exponent(cq.Symbol('theta_0'))).on(q3)
@@ -44,50 +45,50 @@ class MyAnsatz(ofcq.VariationalAnsatz):
         return cq.LineQubit.range(4)
 
 
+
 #%%
 
-diatomic_bond_length = .7414
-geometry = [('H', (0., 0., 0.)), 
-            ('H', (0., 0., diatomic_bond_length))]
+
+# Molecule Properties
+bond_lengths = [float('{0:.1f}'.format(0.3 + 0.1 * x)) for x in range(23)]
 basis = 'sto-3g'
 multiplicity = 1
 charge = 0
-description = format(diatomic_bond_length)
 
-molecule = of.MolecularData(
-    geometry,
-    basis,
-    multiplicity,
-    description=description)
-# H2 comes for free..  no psi4 needed. 
-molecule.load()
+# Optimzation Parameters
+algorithm = ScipyOptimizationAlgorithm(
+    kwargs={'method': 'COBYLA'},
+    options={'maxiter': 100},
+    uses_bounds=False)
 
-hamiltonian = molecule.get_molecular_hamiltonian()
-print("Bond Length in Angstroms: {}".format(diatomic_bond_length))
-print("Hartree Fock (mean-field) energy in Hartrees: {}".format(molecule.hf_energy))
-print("FCI (Exact) energy in Hartrees: {}".format(molecule.fci_energy))
+optimization_params = OptimizationParams(
+    algorithm=algorithm)
 
-#%%
-
-## Transform into Qubit Hamiltonian
+# Wave Function Ansatz (parameterized guess) U(theta)
 ansatz = MyAnsatz()
-objective = ofcq.HamiltonianObjective(hamiltonian)
 q0, q1, _, _ = ansatz.qubits
+
+# Initialize to |11> state
+##  U(theta)|11> --> best guess ground state
 preparation_circuit = cq.Circuit.from_ops(
     cq.X(q0),
     cq.X(q1))
+
+#%%
+
+## Run a study on a single bond length
+molecule = of.MolecularData([('H', (0., 0., 0.)),
+                             ('H', (0., 0., 0.7414))],
+                            'sto-3g', 1, 0)
+molecule.load()
+objective = ofcq.HamiltonianObjective(molecule.get_molecular_hamiltonian())
+
 study = ofcq.VariationalStudy(
     name='my_hydrogen_study',
     ansatz=ansatz,
     objective=objective,
     preparation_circuit=preparation_circuit)
-print(study.circuit)
 
-#%% 
-
-optimization_params = OptimizationParams(
-    algorithm=COBYLA,
-    initial_guess=[0.01])
 result = study.optimize(optimization_params)
 print("Initial state energy in Hartrees: {}".format(molecule.hf_energy))
 print("Optimized energy result in Hartree: {}".format(result.optimal_value))
@@ -96,14 +97,13 @@ print("Exact energy result in Hartees for reference: {}".format(molecule.fci_ene
 
 #%%
 
-## Run the same study on multiple bond lengths
-
-bond_lengths = [float('{0:.1f}'.format(0.3 + 0.1 * x)) for x in range(23)]
+# for storing results at different bond lengths
 hartree_fock_energies = []
 optimized_energies = []
 exact_energies = []
 
 for diatomic_bond_length in bond_lengths:
+    # construct molecule
     geometry = [('H', (0., 0., 0.)), 
                 ('H', (0., 0., diatomic_bond_length))]
 
@@ -114,20 +114,26 @@ for diatomic_bond_length in bond_lengths:
                                 multiplicity, 
                                 charge,
                                 description=description)
+    # compute the molecular hamiltonian in the orbital basis
     molecule = run_psi4(molecule,
                         run_mp2=True,
                         run_cisd=True,
                         run_ccsd=True,
                         run_fci=True)
+        
     hamiltonian = molecule.get_molecular_hamiltonian()
     
+    # Construct VQE study
     study = ofcq.VariationalStudy(
         name='my_hydrogen_study',
         ansatz=ansatz,
         objective=ofcq.HamiltonianObjective(hamiltonian),
         preparation_circuit=preparation_circuit)
     
+    # do VQE
     result = study.optimize(optimization_params)
+    
+    # store results
     hartree_fock_energies.append(molecule.hf_energy)
     optimized_energies.append(result.optimal_value)
     exact_energies.append(molecule.fci_energy)
@@ -149,7 +155,6 @@ ax.set_ylabel(r'E Hartrees')
 ax.set_title(r'H$_2$ bond dissociation curve')
 ax.spines['right'].set_visible(False)
 ax.spines['top'].set_visible(False)
-#bond_lengths = [float(x) for x in bond_lengths]
 ax.plot(bond_lengths, hartree_fock_energies, label='Hartree-Fock')
 ax.plot(bond_lengths, optimized_energies, '*', label='Optimized')
 ax.plot(bond_lengths, exact_energies, '--', label='Exact')


### PR DESCRIPTION
The h2_example no computes the correct energy values.
There was a - missing on the exponent to one of the X operators.
Whoops.